### PR TITLE
FIX: Correct shebang

### DIFF
--- a/get
+++ b/get
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 
 # The install script is licensed under the MIT license Glide itself is under.
 # See https://github.com/Masterminds/glide/blob/master/LICENSE for more details.


### PR DESCRIPTION
As mentioned in https://github.com/Masterminds/glide/issues/524, the shebang:

```
#!/usr/bin/env sh
```

Is incorrect. The correct one is:

```
#!/bin/sh
```
##### Reason:

 `/bin/sh` is the _only_ binary that is guaranteed to be at this path (excepted on Android, which has it in `/system/bin/sh`), as per [this document](http://in-ulm.de/~mascheck/various/shells/). And as per [that document](http://in-ulm.de/~mascheck/various/shebang/#env):

> However, the location of env(1) might vary. [...] it cannot strictly assure "portability" of a script.
