### PR TITLE
Add support for MinGW shell in windows

### DIFF
--- a/get
+++ b/get
@@ -48,11 +48,17 @@ initArch() {
 		aarch64) ARCH="arm64";;
 		x86) ARCH="386";;
 		x86_64) ARCH="amd64";;
+		i686) ARCH="386";;
 	esac
 }
 
 initOS() {
-    OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+	OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+
+	if [[ "${OS}" == mingw* ]] ; then
+		# Minimalist GNU for Windows
+		OS='windows'
+	fi
 }
 
 downloadFile() {


### PR DESCRIPTION
The default Windows git client ships with a great feature that lets users right-click anywhere and launch a bash shell with git loaded. The shell is [MinGW](http://www.mingw.org), and reports itself as `mingw32_nt-6.1` or similar. This PR simply detects that and allows glide to successfully install. It also adds a catch for how MinGW reports its architecture on 32-bit systems.
