### PR TITLE
Hide progress output from curl

### DIFF
--- a/get
+++ b/get
@@ -85,7 +85,7 @@ downloadFile() {
 		GLIDE_TMP_FILE="/tmp/$GLIDE_DIST"
         echo "Downloading $DOWNLOAD_URL"
 		if type "curl" > /dev/null; then
-			curl -L "$DOWNLOAD_URL" -o "$GLIDE_TMP_FILE"
+			curl -s -L "$DOWNLOAD_URL" -o "$GLIDE_TMP_FILE"
 		elif type "wget" > /dev/null; then
 			wget -q -O "$GLIDE_TMP_FILE" "$DOWNLOAD_URL"
 		fi


### PR DESCRIPTION
Add `-s` (silent) option to downloading the release.

Not sure if there is a reason for showing the progress output. I assumed that got forgotten because  all other curl/wget calls don't log progress.