### PR TITLE
Add cleanup to script

### DIFF
--- a/get
+++ b/get
@@ -98,6 +98,8 @@ installFile() {
 	tar xf "$GLIDE_TMP_FILE" -C "$GLIDE_TMP"
 	GLIDE_TMP_BIN="$GLIDE_TMP/$OS-$ARCH/$PROJECT_NAME"
 	cp "$GLIDE_TMP_BIN" "$LGOBIN"
+	rm -rf $GLIDE_TMP
+	rm -f $GLIDE_TMP_FILE
 }
 
 bye() {
@@ -120,6 +122,7 @@ testVersion() {
 	echo "$GLIDE_VERSION installed succesfully"
 }
 
+	
 # Execution
 
 #Stop execution on any error


### PR DESCRIPTION
Without cleaning up after script finishes you'll have the following problem:
For example, user1 installs glide with this script. It finishes successfully.
If user2 will try to do the same thing after user1 he will get errors, because there is already file and directory with glide owned by user1. Pretty nasty bug on servers with multiple users.