### PR TITLE
Update get script

### DIFF
--- a/get
+++ b/get
@@ -112,7 +112,7 @@ testVersion() {
 	set +e
 	GLIDE="$(which $PROJECT_NAME)"
 	if [ "$?" = "1" ]; then
-		echo "$PROJECT_NAME not found. Did you add "'$LGOBIN'" to your "'$PATH?'
+		echo "$PROJECT_NAME not found. Did you add $LGOBIN to your "'$PATH?'
 		exit 1
 	fi
 	set -e


### PR DESCRIPTION
There are a lot of people having issues with the output of the install script. Printing the variable instead of just printing the name of the variable should avoid confusion and enable users to add the correct path to their $PATH.

Makes people less likely to stumble upon issues like #734, #894