### PR TITLE
Handled rate limiting in public CI/CD tool

### DIFF
--- a/get
+++ b/get
@@ -71,10 +71,20 @@ initDownloadTool() {
 		DOWNLOAD_TOOL="curl"
 	elif type "wget" > /dev/null; then
 		DOWNLOAD_TOOL="wget"
-	else 
+	else
 		fail "You need curl or wget as download tool. Please install it first before continue"
 	fi
 	echo "Using $DOWNLOAD_TOOL as download tool"
+}
+
+initGithubAuth() {
+	if [ ! -z "$GITHUB_USER$GITHUB_TOKEN" ]; then
+		if [ "$DOWNLOAD_TOOL" = "curl" ]; then
+			AUTH_OPT="-u $GITHUB_USER:$GITHUB_TOKEN"
+		elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
+			AUTH_OPT="--user $GITHUB_USER --password $GITHUB_TOKEN"
+		fi
+	fi
 }
 
 get() {
@@ -102,9 +112,9 @@ getFile() {
 	local url="$1"
 	local filePath="$2"
 	if [ "$DOWNLOAD_TOOL" = "curl" ]; then
-		curl -L "$url" -o "$filePath"
+		curl $AUTH_OPT -L "$url" -o "$filePath"
 	elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
-		wget -O "$filePath" "$url"
+		wget $AUTH_OPT -O "$filePath" "$url"
 	fi
 }
 
@@ -157,7 +167,7 @@ testVersion() {
 	echo "$GLIDE_VERSION installed successfully"
 }
 
-	
+
 # Execution
 
 #Stop execution on any error
@@ -167,6 +177,7 @@ set -e
 initArch
 initOS
 initDownloadTool
+initGithubAuth
 downloadFile
 installFile
 testVersion

--- a/get
+++ b/get
@@ -111,7 +111,7 @@ getFile() {
 downloadFile() {
 	get TAG https://glide.sh/version
 	echo "TAG=$TAG"
-	LATEST_RELEASE_URL="https://api.github.com/repos/Masterminds/$PROJECT_NAME/releases/tags/$TAG"
+	LATEST_RELEASE_URL="https://github.com/Masterminds/$PROJECT_NAME/releases/download/$TAG/$PROJECT_NAME-$TAG-$OS-$ARCH.tar.gz"
 	echo "LATEST_RELEASE_URL=$LATEST_RELEASE_URL"
 	get LATEST_RELEASE_JSON $LATEST_RELEASE_URL
 	GLIDE_DIST="glide-$TAG-$OS-$ARCH.tar.gz"

--- a/get
+++ b/get
@@ -93,12 +93,12 @@ get() {
 	local httpStatusCode
 	echo "Getting $url"
 	if [ "$DOWNLOAD_TOOL" = "curl" ]; then
-		httpResponse=$(curl -sL --write-out HTTPSTATUS:%{http_code} "$url")
+		httpResponse=$(curl $AUTH_OPT -sL --write-out HTTPSTATUS:%{http_code} "$url")
 		httpStatusCode=$(echo $httpResponse | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 		body=$(echo "$httpResponse" | sed -e 's/HTTPSTATUS\:.*//g')
 	elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
 		tmpFile=$(mktemp)
-		body=$(wget --server-response --content-on-error -q -O - "$url" 2> $tmpFile || true)
+		body=$(wget $AUTH_OPT --server-response --content-on-error -q -O - "$url" 2> $tmpFile || true)
 		httpStatusCode=$(cat $tmpFile | awk '/^  HTTP/{print $2}')
 	fi
 	if [ "$httpStatusCode" != 200 ]; then

--- a/get
+++ b/get
@@ -132,7 +132,6 @@ downloadFile() {
 			echo "Sorry, we dont have a dist for your system: $OS $ARCH"
 			fail "You can ask one here: https://github.com/Masterminds/$PROJECT_NAME/issues"
 		else
-			GLIDE_TMP_FILE="/tmp/$GLIDE_DIST"
 			echo "Downloading $DOWNLOAD_URL"
 			getFile "$DOWNLOAD_URL" "$GLIDE_TMP_FILE"
 		fi

--- a/get
+++ b/get
@@ -115,6 +115,7 @@ downloadFile() {
 	get TAG https://glide.sh/version
 	echo "TAG=$TAG"
 	GLIDE_DIST="glide-$TAG-$OS-$ARCH.tar.gz"
+	echo "GLIDE_DIST=$GLIDE_DIST"
 	DOWNLOAD_URL="https://github.com/Masterminds/$PROJECT_NAME/releases/download/$TAG/$GLIDE_DIST"
 	GLIDE_TMP_FILE="/tmp/$GLIDE_DIST"
 	echo "Downloading $DOWNLOAD_URL"
@@ -125,7 +126,6 @@ downloadFile() {
 		LATEST_RELEASE_URL="https://api.github.com/repos/Masterminds/$PROJECT_NAME/releases/tags/$TAG"
 		echo "LATEST_RELEASE_URL=$LATEST_RELEASE_URL"
 		get LATEST_RELEASE_JSON $LATEST_RELEASE_URL
-		echo "GLIDE_DIST=$GLIDE_DIST"
 		# || true forces this command to not catch error if grep does not find anything
 		DOWNLOAD_URL=$(echo "$LATEST_RELEASE_JSON" | grep 'browser_' | cut -d\" -f4 | grep "$GLIDE_DIST") || true
 		if [ -z "$DOWNLOAD_URL" ]; then

--- a/get
+++ b/get
@@ -83,12 +83,12 @@ get() {
 	local httpStatusCode
 	echo "Getting $url"
 	if [ "$DOWNLOAD_TOOL" = "curl" ]; then
-		httpResponse=$(curl $AUTH_OPT -sL --write-out HTTPSTATUS:%{http_code} "$url")
+		httpResponse=$(curl -sL --write-out HTTPSTATUS:%{http_code} "$url")
 		httpStatusCode=$(echo $httpResponse | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 		body=$(echo "$httpResponse" | sed -e 's/HTTPSTATUS\:.*//g')
 	elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
 		tmpFile=$(mktemp)
-		body=$(wget $AUTH_OPT --server-response --content-on-error -q -O - "$url" 2> $tmpFile || true)
+		body=$(wget --server-response --content-on-error -q -O - "$url" 2> $tmpFile || true)
 		httpStatusCode=$(cat $tmpFile | awk '/^  HTTP/{print $2}')
 	fi
 	if [ "$httpStatusCode" != 200 ]; then

--- a/get
+++ b/get
@@ -71,7 +71,7 @@ initDownloadTool() {
 		DOWNLOAD_TOOL="curl"
 	elif type "wget" > /dev/null; then
 		DOWNLOAD_TOOL="wget"
-	else 
+	else
 		fail "You need curl or wget as download tool. Please install it first before continue"
 	fi
 	echo "Using $DOWNLOAD_TOOL as download tool"
@@ -117,26 +117,26 @@ downloadFile() {
 	GLIDE_DIST="glide-$TAG-$OS-$ARCH.tar.gz"
 	DOWNLOAD_URL="https://github.com/Masterminds/$PROJECT_NAME/releases/download/$TAG/$GLIDE_DIST"
 	GLIDE_TMP_FILE="/tmp/$GLIDE_DIST"
-    echo "Downloading $DOWNLOAD_URL"
+	echo "Downloading $DOWNLOAD_URL"
 	httpStatusCode=$(getFile "$DOWNLOAD_URL" "$GLIDE_TMP_FILE")
 	if [ "$httpStatusCode" -ne 200 ]; then
-	    echo "Did not find a release for your system: $OS $ARCH"
-	    echo "Trying to find a release on the github api."
-        LATEST_RELEASE_URL="https://api.github.com/repos/Masterminds/$PROJECT_NAME/releases/tags/$TAG"
-        echo "LATEST_RELEASE_URL=$LATEST_RELEASE_URL"
-        get LATEST_RELEASE_JSON $LATEST_RELEASE_URL
-        echo "GLIDE_DIST=$GLIDE_DIST"
-        # || true forces this command to not catch error if grep does not find anything
-        DOWNLOAD_URL=$(echo "$LATEST_RELEASE_JSON" | grep 'browser_' | cut -d\" -f4 | grep "$GLIDE_DIST") || true
-        if [ -z "$DOWNLOAD_URL" ]; then
-            echo "Sorry, we dont have a dist for your system: $OS $ARCH"
-            fail "You can ask one here: https://github.com/Masterminds/$PROJECT_NAME/issues"
-        else
-            GLIDE_TMP_FILE="/tmp/$GLIDE_DIST"
-            echo "Downloading $DOWNLOAD_URL"
-            getFile "$DOWNLOAD_URL" "$GLIDE_TMP_FILE"
-        fi
-    fi
+		echo "Did not find a release for your system: $OS $ARCH"
+		echo "Trying to find a release on the github api."
+		LATEST_RELEASE_URL="https://api.github.com/repos/Masterminds/$PROJECT_NAME/releases/tags/$TAG"
+		echo "LATEST_RELEASE_URL=$LATEST_RELEASE_URL"
+		get LATEST_RELEASE_JSON $LATEST_RELEASE_URL
+		echo "GLIDE_DIST=$GLIDE_DIST"
+		# || true forces this command to not catch error if grep does not find anything
+		DOWNLOAD_URL=$(echo "$LATEST_RELEASE_JSON" | grep 'browser_' | cut -d\" -f4 | grep "$GLIDE_DIST") || true
+		if [ -z "$DOWNLOAD_URL" ]; then
+			echo "Sorry, we dont have a dist for your system: $OS $ARCH"
+			fail "You can ask one here: https://github.com/Masterminds/$PROJECT_NAME/issues"
+		else
+			GLIDE_TMP_FILE="/tmp/$GLIDE_DIST"
+			echo "Downloading $DOWNLOAD_URL"
+			getFile "$DOWNLOAD_URL" "$GLIDE_TMP_FILE"
+		fi
+	fi
 }
 
 installFile() {
@@ -168,7 +168,7 @@ testVersion() {
 	echo "$GLIDE_VERSION installed successfully"
 }
 
-	
+
 # Execution
 
 #Stop execution on any error

--- a/get
+++ b/get
@@ -102,30 +102,41 @@ getFile() {
 	local url="$1"
 	local filePath="$2"
 	if [ "$DOWNLOAD_TOOL" = "curl" ]; then
-		curl -L "$url" -o "$filePath"
+		httpStatusCode=$(curl -s -w '%{http_code}' -L "$url" -o "$filePath")
 	elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
-		wget -O "$filePath" "$url"
+		body=$(wget --server-response --content-on-error -q -O "$filePath" "$url")
+		httpStatusCode=$(cat $tmpFile | awk '/^  HTTP/{print $2}')
 	fi
+	echo "$httpStatusCode"
 }
+
 
 downloadFile() {
 	get TAG https://glide.sh/version
 	echo "TAG=$TAG"
-	LATEST_RELEASE_URL="https://github.com/Masterminds/$PROJECT_NAME/releases/download/$TAG/$PROJECT_NAME-$TAG-$OS-$ARCH.tar.gz"
-	echo "LATEST_RELEASE_URL=$LATEST_RELEASE_URL"
-	get LATEST_RELEASE_JSON $LATEST_RELEASE_URL
 	GLIDE_DIST="glide-$TAG-$OS-$ARCH.tar.gz"
-	echo "GLIDE_DIST=$GLIDE_DIST"
-	# || true forces this command to not catch error if grep does not find anything
-	DOWNLOAD_URL=$(echo "$LATEST_RELEASE_JSON" | grep 'browser_' | cut -d\" -f4 | grep "$GLIDE_DIST") || true
-	if [ -z "$DOWNLOAD_URL" ]; then
-        echo "Sorry, we dont have a dist for your system: $OS $ARCH"
-        fail "You can ask one here: https://github.com/Masterminds/$PROJECT_NAME/issues"
-	else
-		GLIDE_TMP_FILE="/tmp/$GLIDE_DIST"
-        echo "Downloading $DOWNLOAD_URL"
-		getFile "$DOWNLOAD_URL" "$GLIDE_TMP_FILE"
-	fi
+	DOWNLOAD_URL="https://github.com/Masterminds/$PROJECT_NAME/releases/download/$TAG/$GLIDE_DIST"
+	GLIDE_TMP_FILE="/tmp/$GLIDE_DIST"
+    echo "Downloading $DOWNLOAD_URL"
+	httpStatusCode=$(getFile "$DOWNLOAD_URL" "$GLIDE_TMP_FILE")
+	if [ "$httpStatusCode" -ne 200 ]; then
+	    echo "Did not find a release for your system: $OS $ARCH"
+	    echo "Trying to find a release on the github api."
+        LATEST_RELEASE_URL="https://api.github.com/repos/Masterminds/$PROJECT_NAME/releases/tags/$TAG"
+        echo "LATEST_RELEASE_URL=$LATEST_RELEASE_URL"
+        get LATEST_RELEASE_JSON $LATEST_RELEASE_URL
+        echo "GLIDE_DIST=$GLIDE_DIST"
+        # || true forces this command to not catch error if grep does not find anything
+        DOWNLOAD_URL=$(echo "$LATEST_RELEASE_JSON" | grep 'browser_' | cut -d\" -f4 | grep "$GLIDE_DIST") || true
+        if [ -z "$DOWNLOAD_URL" ]; then
+            echo "Sorry, we dont have a dist for your system: $OS $ARCH"
+            fail "You can ask one here: https://github.com/Masterminds/$PROJECT_NAME/issues"
+        else
+            GLIDE_TMP_FILE="/tmp/$GLIDE_DIST"
+            echo "Downloading $DOWNLOAD_URL"
+            getFile "$DOWNLOAD_URL" "$GLIDE_TMP_FILE"
+        fi
+    fi
 }
 
 installFile() {

--- a/get
+++ b/get
@@ -71,20 +71,10 @@ initDownloadTool() {
 		DOWNLOAD_TOOL="curl"
 	elif type "wget" > /dev/null; then
 		DOWNLOAD_TOOL="wget"
-	else
+	else 
 		fail "You need curl or wget as download tool. Please install it first before continue"
 	fi
 	echo "Using $DOWNLOAD_TOOL as download tool"
-}
-
-initGithubAuth() {
-	if [ ! -z "$GITHUB_USER$GITHUB_TOKEN" ]; then
-		if [ "$DOWNLOAD_TOOL" = "curl" ]; then
-			AUTH_OPT="-u $GITHUB_USER:$GITHUB_TOKEN"
-		elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
-			AUTH_OPT="--user $GITHUB_USER --password $GITHUB_TOKEN"
-		fi
-	fi
 }
 
 get() {
@@ -112,9 +102,9 @@ getFile() {
 	local url="$1"
 	local filePath="$2"
 	if [ "$DOWNLOAD_TOOL" = "curl" ]; then
-		curl $AUTH_OPT -L "$url" -o "$filePath"
+		curl -L "$url" -o "$filePath"
 	elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
-		wget $AUTH_OPT -O "$filePath" "$url"
+		wget -O "$filePath" "$url"
 	fi
 }
 
@@ -167,7 +157,7 @@ testVersion() {
 	echo "$GLIDE_VERSION installed successfully"
 }
 
-
+	
 # Execution
 
 #Stop execution on any error
@@ -177,7 +167,6 @@ set -e
 initArch
 initOS
 initDownloadTool
-initGithubAuth
 downloadFile
 installFile
 testVersion


### PR DESCRIPTION
I had an issue where I was experiencing rate limiting when trying to install glide on my travis build instance (https://travis-ci.org/drewsonne/go-gocd/jobs/289153125#L649) so I've added an option which will check for environment variables `$GITHUB_USER` and `$GITHUB_TOKEN` and if it finds them, will use them as basic for auth wget and curl.