### PR TITLE
If GOPATH is not set, check the existence of default GOPATH

### DIFF
--- a/get
+++ b/get
@@ -25,7 +25,7 @@ verifyGoInstallation() {
 	fi
 	if [ -z "$GOPATH" ]; then
 	    # Verify if default GOPATH of Go >=1.8 is used
-	    GOPATH="${HOME}/go"
+	    GOPATH=$(go env GOPATH)
 	    if [ ! -d "$GOPATH" ]; then
 		fail "$PROJECT_NAME needs environment variable "'$GOPATH'". Set it before continue."
 	    fi

--- a/get
+++ b/get
@@ -24,7 +24,11 @@ verifyGoInstallation() {
 		fail "$PROJECT_NAME needs go. Please install it first."
 	fi
 	if [ -z "$GOPATH" ]; then
+	    # Verify if default GOPATH of Go >=1.8 is used
+	    GOPATH="${HOME}/go"
+	    if [ ! -d "$GOPATH" ]; then
 		fail "$PROJECT_NAME needs environment variable "'$GOPATH'". Set it before continue."
+	    fi
 	fi
 	if [ -n "$GOBIN" ]; then
 		if [ ! -d "$GOBIN" ]; then


### PR DESCRIPTION
With Go versions 1.8 and newer, the GOPATH is not required to be set and a default can be used. Since glide itself uses the same process (in path/path.go) there's no need for the installation script to require setting the environment variable.