### PR TITLE
Add arm64 in available arch

### DIFF
--- a/get
+++ b/get
@@ -51,6 +51,7 @@ initArch() {
 		armv6*) ARCH="armv6";;
 		armv7*) ARCH="armv7";;
 		aarch64) ARCH="arm64";;
+		arm64) ARCH="arm64";;
 		x86) ARCH="386";;
 		x86_64) ARCH="amd64";;
 		i686) ARCH="386";;


### PR DESCRIPTION
I'm trying to build a project which uses glide on a GitLab runner using
an `arm64v8` Docker image.
For an obscure reason, `uname -m` returns `arm64` instead of `aarch64`.